### PR TITLE
Add support for searching MacOS Homebrew locations

### DIFF
--- a/fzf.plugin.zsh
+++ b/fzf.plugin.zsh
@@ -5,3 +5,9 @@
 [ -f /usr/share/doc/fzf/examples/completion.zsh ] && source /usr/share/doc/fzf/examples/completion.zsh
 [ -f /usr/share/doc/fzf/examples/key-bindings.zsh ] && source /usr/share/doc/fzf/examples/key-bindings.zsh
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+if [[ "$(uname -s)" == "Darwin" && "$(command -v brew)" != "" ]] ; then
+  local FZF_HOME=$(brew --prefix)/opt/fzf
+  [ -f $FZF_HOME/shell/completion.zsh ] && source $FZF_HOME/shell/completion.zsh
+  [ -f $FZF_HOME/shell/key-bindings.zsh ] && source $FZF_HOME/shell/key-bindings.zsh
+fi


### PR DESCRIPTION
Since Homebrew on MacOS doesn't put the completion/keybindings in any of the locations being searched, try the locations based on the Homebrew prefix is MacOS is the OS and brew is installed.