### PR TITLE
feat: added support for `fzf` installed with `dnf` pkg manager

### DIFF
--- a/fzf.plugin.zsh
+++ b/fzf.plugin.zsh
@@ -2,6 +2,7 @@
 
 
 if command -v fzf &> /dev/null; then
+    [ -f /usr/share/fzf/shell/key-bindings.zsh ] && source /usr/share/fzf/shell/key-bindings.zsh
     [ -f /usr/share/fzf/completion.zsh ] && source /usr/share/fzf/completion.zsh
     [ -f /usr/share/fzf/key-bindings.zsh ] && source /usr/share/fzf/key-bindings.zsh
     [ -f /usr/share/doc/fzf/examples/completion.zsh ] && source /usr/share/doc/fzf/examples/completion.zsh


### PR DESCRIPTION
Hi! dear Zap team - this small contribution is to add the `fzf-bindings` source to installations made with the `dnf` package manager.

I trust the instructions contained in the compiled package for Fedora 37 Workstation, which are:

> fzf provides several niceties, such as shell completion, shell key bindings,
and a vim plugin. In Fedora, we only enable the shell completion and install
the plugin for vim and neovim by default as they are generally non-intrusive.
The key bindings are installed but not enabled.

> To enable shell key bindings, source the applicable script from
/usr/share/fzf/shell from your shell initialization. For example, use
/usr/share/fzf/shell/key-bindings.bash in ~/.bashrc for user-wide bash.

> Source: README.fedora

Signed-off-by: Wuelner Martínez <wuelner.martinez@outlook.com>